### PR TITLE
Style/main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.16",
         "globals": "^15.14.0",
-        "prettier": "^3.4.2",
+        "prettier": "^3.5.0",
         "vite": "^6.0.5",
         "vite-plugin-svgr": "^4.3.0"
       }
@@ -4650,9 +4650,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.0.tgz",
+      "integrity": "sha512-quyMrVt6svPS7CjQ9gKb3GLEX/rl3BCL2oa/QkNcXv4YNVBC9olt3s+H7ukto06q7B1Qz46PbrKLO34PR6vXcA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.16",
     "globals": "^15.14.0",
-    "prettier": "^3.4.2",
+    "prettier": "^3.5.0",
     "vite": "^6.0.5",
     "vite-plugin-svgr": "^4.3.0"
   }

--- a/src/components/Card/ListCard.style.js
+++ b/src/components/Card/ListCard.style.js
@@ -122,7 +122,6 @@ const CardListContainer = styled.div`
   justify-content: center;
   flex-wrap: wrap;
   max-width: 1200px;
-  margin: 0 auto;
   gap: 20px;
   transition: transform 0.3s ease-in-out;
   will-change: transform;

--- a/src/components/Card/MessageCard.jsx
+++ b/src/components/Card/MessageCard.jsx
@@ -34,7 +34,7 @@ function MessageCard({
   onDelete,
   onClick,
 }) {
-  console.log(relationship);
+
   return (
     <MessageCardContainer onClick={onClick}>
       <SenderContainer>

--- a/src/components/TextField/TextEditor.style.js
+++ b/src/components/TextField/TextEditor.style.js
@@ -11,14 +11,14 @@ const fontMap = {
 
 const StyledQuill = styled(ReactQuill)`
   .ql-toolbar {
-    width: 720px;
+    width: 100%;
     height: 40px;
     border-radius: 8px 8px 0 0;
     border: 1px solid ${({ theme }) => theme.colors.gray[300]};
   }
 
   .ql-container {
-    width: 720px;
+    width: 100%;
     height: 220px;
     border-radius: 0 0 8px 8px;
     border: 1px solid ${({ theme }) => theme.colors.gray[300]};

--- a/src/pages/List/List.style.js
+++ b/src/pages/List/List.style.js
@@ -52,7 +52,7 @@ const PostButtonWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-top: 60px;
+  margin: 60px 0 80px;
 `;
 
 const ArrowButtonWrapper = styled.div`

--- a/src/pages/List/List.style.js
+++ b/src/pages/List/List.style.js
@@ -4,13 +4,14 @@ const ListWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 100%
-    padding: 0 24px;
+  width: 100%;
+  padding: 0 24px;
   margin: 50px auto;
   position: relative;
 `;
 
 const CardSlider = styled.div`
+  width: 1160px;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
@@ -28,6 +29,7 @@ const CardSlider = styled.div`
 `;
 
 const CardContainer = styled.div`
+  width: 1160px;
   display: flex;
   gap: 20px;
   transition: transform 0.3s ease-in-out;

--- a/src/pages/Main/Main.style.js
+++ b/src/pages/Main/Main.style.js
@@ -38,6 +38,11 @@ export const Wrapper = styled.div`
 
     &.img-box, &.buttonWrapper {
         ${({ theme }) => theme.flexLayout};
+        
+    }
+
+    &.buttonWrapper {
+        padding-bottom: 80px;
     }
 
     &.img-box {

--- a/src/pages/PostAndMessage/MessageWrite.jsx
+++ b/src/pages/PostAndMessage/MessageWrite.jsx
@@ -123,13 +123,15 @@ function MessageWrite() {
             onSelect={setSelectedRelationship}
           />
         </P.Section>
-        <P.Section className="">
+        <P.Section>
           <P.SectionTitle>내용을 입력해 주세요</P.SectionTitle>
-          <TextEditor
-            content={content}
-            selectedFont={selectedFont}
-            setContent={setContent}
-          />
+          <P.Wrapper className="text-editor-wrap">
+            <TextEditor
+              content={content}
+              selectedFont={selectedFont}
+              setContent={setContent}
+            />
+          </P.Wrapper>
         </P.Section>
         <P.Section className="select-font">
           <P.SectionTitle>폰트 선택</P.SectionTitle>

--- a/src/pages/PostAndMessage/PostAndMessage.style.js
+++ b/src/pages/PostAndMessage/PostAndMessage.style.js
@@ -5,6 +5,7 @@ export const Wrapper = styled.div`
 
   &.section-wrap {
     ${({ theme }) => theme.flexLayout("column")}
+    padding-bottom: 150px;
     width: 100%;
     max-width: 720px;
   }

--- a/src/pages/PostAndMessage/PostAndMessage.style.js
+++ b/src/pages/PostAndMessage/PostAndMessage.style.js
@@ -8,6 +8,9 @@ export const Wrapper = styled.div`
     padding-bottom: 150px;
     width: 100%;
     max-width: 720px;
+    @media (max-width: 768px) {
+      padding: 0 24px;
+    }
   }
 
   &.txt-box {
@@ -26,8 +29,13 @@ export const Wrapper = styled.div`
   }
 
   &.profile-list-wrap {
-    ${({ theme }) => theme.flexLayout()}
+    ${({ theme }) => theme.flexLayout(undefined, "flex-start")}
+    flex-wrap: wrap;
     gap: 4px;
+  }
+  &.text-editor-wrap {
+    width: 100%;
+    max-width: 720px;
   }
 `;
 

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -63,13 +63,13 @@ const GlobalStyle = createGlobalStyle`
   }
 
   // 나눔명조
-  @font-face {
+@font-face {
     font-family: 'Nanum Myeongjo';
-    font-weight: 400;
+    font-weight: 700;
     font-style: normal;
     font-display: swap;
-    src: url('https://cdn.jsdelivr.net/gh/fonts-archive/NanumMyeongjo/NanumMyeongjo.woff2') format('woff2'),
-  }
+    src: url('https://cdn.jsdelivr.net/gh/fonts-archive/NanumMyeongjo/NanumMyeongjoBold.woff2') format('woff2'),
+}
   
   // 나눔손글씨 손편지체
   @font-face {


### PR DESCRIPTION
## #️⃣연관된 이슈, 작업

전반적인 수정 작업입니다.

## 📝작업 내용

전체 페이지 하단에 padding값을 추가하여, 아래 여백이 생기도록 했습니다.

console.log 삭제

한 페이지에 보여지는 카드 개수가 4개 미만일 때, 가운데 정렬로 보이는 레이아웃 수정

PostCreate, MessageWrite 페이지 반응형 구현 (텍스트 에디터, 프로필 리스트, 좌우 패딩값)

카드 메세지의 사용자 커스텀 폰트 중, 나눔명조의 font-weight를 700으로 변경했습니다.
(기존 400은 잘 보이지 않는 이슈)